### PR TITLE
Task start and finish time added

### DIFF
--- a/src/main/java/domen/domain/TaskService.java
+++ b/src/main/java/domen/domain/TaskService.java
@@ -15,20 +15,17 @@ public class TaskService {
     }
 
     public Task create(String title, String description) {
-        if (title == null || title.isBlank())
-            throw new IllegalArgumentException("Title cannot be null or empty");
-
-        Task task = new Task(UUID.randomUUID().toString(), title, description, TaskStatus.NEW, null, null);
-        taskRepository.save(task);
-        return task;
+        return buildAndSaveTask(title, description, null, null);
     }
 
     public Task create(String title, String description, LocalDateTime startDateTime, LocalDateTime finishDateTime) {
+        validateTaskDateTime(startDateTime, finishDateTime);
+        return buildAndSaveTask(title, description, startDateTime, finishDateTime);
+    }
+
+    private Task buildAndSaveTask(String title, String description, LocalDateTime startDateTime, LocalDateTime finishDateTime) {
         if (title == null || title.isBlank())
             throw new IllegalArgumentException("Title cannot be null or empty");
-
-        validateTaskDateTime(startDateTime, finishDateTime);
-
         Task task = new Task(UUID.randomUUID().toString(), title, description, TaskStatus.NEW, startDateTime, finishDateTime);
         taskRepository.save(task);
         return task;

--- a/src/main/java/domen/domain/TaskService.java
+++ b/src/main/java/domen/domain/TaskService.java
@@ -32,7 +32,7 @@ public class TaskService {
     }
 
     public Task update(String id, String newTitle, String newDescription, TaskStatus newStatus) {
-        Task updatedTask = getTaskOrThrow(id).copyWithUpdate(newTitle, newDescription, newStatus);
+        Task updatedTask = getTask(id).copyWithUpdate(newTitle, newDescription, newStatus);
 
         taskRepository.update(updatedTask);
         return updatedTask;
@@ -40,13 +40,13 @@ public class TaskService {
 
     public Task assignTime(String id, LocalDateTime startDateTime, LocalDateTime finishDateTime) {
         validateTaskDateTime(startDateTime, finishDateTime);
-        Task updatedTask = getTaskOrThrow(id).copyWithUpdate(startDateTime, finishDateTime);
+        Task updatedTask = getTask(id).copyWithUpdate(startDateTime, finishDateTime);
 
         taskRepository.update(updatedTask);
         return updatedTask;
     }
 
-    private Task getTaskOrThrow(String id) {
+    private Task getTask(String id) {
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("ID cannot be null or empty");
         }

--- a/src/main/java/domen/domain/TaskService.java
+++ b/src/main/java/domen/domain/TaskService.java
@@ -4,6 +4,8 @@ import domen.domain.exception.TaskNotFoundException;
 import domen.domain.model.Task;
 import domen.domain.model.TaskStatus;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,25 +16,41 @@ public class TaskService {
         this.taskRepository = taskRepository;
     }
 
-    public Task create(String title, String description) {
-        if (title == null || title.isEmpty()) {
+    public Task create(String title, String description, LocalDateTime startDateTime, LocalDateTime finishDateTime) {
+        if (title == null || title.isEmpty())
             throw new IllegalArgumentException("Title cannot be null or empty");
-        }
-        Task task = new Task(UUID.randomUUID().toString(), title, description, TaskStatus.NEW);
+
+        validateTaskDateTime(startDateTime, finishDateTime);
+
+        Task task = new Task(UUID.randomUUID().toString(), title, description, TaskStatus.NEW, startDateTime, finishDateTime);
         taskRepository.save(task);
         return task;
     }
 
-    public Task updateTask(String id, String newTitle, String newDescription, TaskStatus newStatus) {
+    public Task update(String id, String newTitle, String newDescription, TaskStatus newStatus, LocalDateTime newStartDateTime, LocalDateTime newFinishDateTime) {
         if (id == null || id.isEmpty()) {
             throw new IllegalArgumentException("ID cannot be null or empty");
         }
 
+
         Task updatedTask = taskRepository.findById(id)
                 .orElseThrow(() -> new TaskNotFoundException("Task with id " + id + " not found"))
-                .copyWith(newTitle, newDescription, newStatus);
+                .copyWith(newTitle, newDescription, newStatus, newStartDateTime, newFinishDateTime);
+
+        LocalDateTime updatedStartDateTime = newStartDateTime != null ? newStartDateTime : updatedTask.startDateTime();
+        LocalDateTime updatedFinishDateTime = newFinishDateTime != null ? newFinishDateTime : updatedTask.finishDateTime();
+
+        validateTaskDateTime(updatedStartDateTime, updatedFinishDateTime);
 
         taskRepository.update(updatedTask);
         return updatedTask;
+    }
+
+    private static void validateTaskDateTime(LocalDateTime startDateTime, LocalDateTime finishDateTime) {
+        if (finishDateTime == null) return;
+        if (startDateTime != null && startDateTime.isAfter(finishDateTime))
+            throw new IllegalArgumentException("Start date cannot be after finish time");
+        if (finishDateTime.isBefore(LocalDateTime.now()))
+            throw new IllegalArgumentException("Finish date cannot be before current time");
     }
 }

--- a/src/main/java/domen/domain/TaskService.java
+++ b/src/main/java/domen/domain/TaskService.java
@@ -32,29 +32,27 @@ public class TaskService {
     }
 
     public Task update(String id, String newTitle, String newDescription, TaskStatus newStatus) {
-        if (id == null || id.isEmpty()) {
-            throw new IllegalArgumentException("ID cannot be null or empty");
-        }
-
-        Task updatedTask = taskRepository.findById(id)
-                .orElseThrow(() -> new TaskNotFoundException("Task with id " + id + " not found"))
-                .copyWithUpdate(newTitle, newDescription, newStatus);
+        Task updatedTask = getTaskOrThrow(id).copyWithUpdate(newTitle, newDescription, newStatus);
 
         taskRepository.update(updatedTask);
         return updatedTask;
     }
 
     public Task assignTime(String id, LocalDateTime startDateTime, LocalDateTime finishDateTime) {
-        if (id == null || id.isEmpty()) {
-            throw new IllegalArgumentException("ID cannot be null or empty");
-        }
         validateTaskDateTime(startDateTime, finishDateTime);
-        Task updatedTask = taskRepository.findById(id).
-                orElseThrow(() -> new TaskNotFoundException("Task with id " + id + " not found"))
-                .copyWithUpdate(startDateTime, finishDateTime);
+        Task updatedTask = getTaskOrThrow(id).copyWithUpdate(startDateTime, finishDateTime);
 
         taskRepository.update(updatedTask);
         return updatedTask;
+    }
+
+    private Task getTaskOrThrow(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID cannot be null or empty");
+        }
+
+        return taskRepository.findById(id)
+                .orElseThrow(() -> new TaskNotFoundException("Task with id " + id + " not found"));
     }
 
     private static void validateTaskDateTime(LocalDateTime startDateTime, LocalDateTime finishDateTime) {

--- a/src/main/java/domen/domain/model/Task.java
+++ b/src/main/java/domen/domain/model/Task.java
@@ -1,16 +1,20 @@
 package domen.domain.model;
 
-import java.util.UUID;
+import java.time.LocalDateTime;
 
-public record Task(String id, String title, String description, TaskStatus status) {
+public record Task(String id, String title, String description, TaskStatus status, LocalDateTime startDateTime,
+                   LocalDateTime finishDateTime) {
 
 
-    public Task copyWith(String newTitle, String newDescription, TaskStatus newStatus) {
+    public Task copyWith(String newTitle, String newDescription, TaskStatus newStatus, LocalDateTime newStartDateTime, LocalDateTime newFinishDateTime) {
         return new Task(
                 this.id,
                 newTitle != null ? newTitle : this.title,
                 newDescription != null ? newDescription : this.description,
-                newStatus != null ? newStatus : this.status);
+                newStatus != null ? newStatus : this.status,
+                newStartDateTime != null ? newStartDateTime : this.startDateTime,
+                newFinishDateTime != null ? newFinishDateTime : this.finishDateTime);
+
 
     }
 }

--- a/src/main/java/domen/domain/model/Task.java
+++ b/src/main/java/domen/domain/model/Task.java
@@ -6,15 +6,25 @@ public record Task(String id, String title, String description, TaskStatus statu
                    LocalDateTime finishDateTime) {
 
 
-    public Task copyWith(String newTitle, String newDescription, TaskStatus newStatus, LocalDateTime newStartDateTime, LocalDateTime newFinishDateTime) {
+    public Task copyWithUpdate(String newTitle, String newDescription, TaskStatus newStatus) {
         return new Task(
                 this.id,
                 newTitle != null ? newTitle : this.title,
                 newDescription != null ? newDescription : this.description,
                 newStatus != null ? newStatus : this.status,
+                this.startDateTime,
+                this.finishDateTime);
+
+
+    }
+
+    public Task copyWithUpdate(LocalDateTime newStartDateTime, LocalDateTime newFinishDateTime) {
+        return new Task(
+                this.id,
+                this.title,
+                this.description,
+                this.status,
                 newStartDateTime != null ? newStartDateTime : this.startDateTime,
                 newFinishDateTime != null ? newFinishDateTime : this.finishDateTime);
-
-
     }
 }

--- a/src/test/java/domen/domain/TaskServiceTest.java
+++ b/src/test/java/domen/domain/TaskServiceTest.java
@@ -43,10 +43,8 @@ class TaskServiceTest {
 
     @Test
     void shouldNotCreateTask() {
-        //given
-        String invalidTitle = null;
         //when then
-        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> taskService.create(invalidTitle, "", null, null));
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> taskService.create(null, "", null, null));
         assertEquals("Title cannot be null or empty", illegalArgumentException.getMessage());
     }
 
@@ -58,7 +56,7 @@ class TaskServiceTest {
         when(taskRepository.findById(id)).thenReturn(Optional.of(original));
 
         //when
-        Task updated = taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS, null, null);
+        Task updated = taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS);
 
         //then
         assertNotNull(updated);
@@ -75,7 +73,7 @@ class TaskServiceTest {
         when(taskRepository.findById(id)).thenReturn(Optional.empty());
         //when then
         TaskNotFoundException ex = assertThrows(TaskNotFoundException.class, () ->
-                taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS, null, null)
+                taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS)
         );
         assertEquals("Task with id " + id + " not found", ex.getMessage());
 
@@ -89,7 +87,7 @@ class TaskServiceTest {
         when(taskRepository.findById(id)).thenReturn(Optional.of(original));
 
         //when
-        Task updated = taskService.update(id, "New title", null, null, null, null);
+        Task updated = taskService.update(id, "New title", null, null);
 
         //then
         assertNotNull(updated);
@@ -104,7 +102,7 @@ class TaskServiceTest {
     void shouldNotUpdateNullId() {
         //when then
         assertThrows(IllegalArgumentException.class, () ->
-                taskService.update(null, "New title", "Description", TaskStatus.NEW, null, null)
+                taskService.update(null, "New title", "Description", TaskStatus.NEW)
         );
     }
 
@@ -114,7 +112,7 @@ class TaskServiceTest {
         when(taskRepository.findById("id")).thenReturn(Optional.empty());
         //when/then
         assertThrows(TaskNotFoundException.class, () ->
-                taskService.update("id", "New title", "New desc", TaskStatus.IN_PROGRESS, null, null)
+                taskService.update("id", "New title", "New desc", TaskStatus.IN_PROGRESS)
         );
         verify(taskRepository, never()).update(any());
     }
@@ -130,6 +128,26 @@ class TaskServiceTest {
                 taskService.create("Title", "Description", start, finish)
         );
         assertEquals("Start date cannot be after finish time", ex.getMessage());
+    }
+
+    @Test
+    void shouldAssignTime() {
+        // given
+        String id = "1";
+        Task original = new Task(id, "Title", "Desc", TaskStatus.NEW, null, null);
+        when(taskRepository.findById(id)).thenReturn(Optional.of(original));
+
+        LocalDateTime start = LocalDateTime.now().plusDays(1);
+        LocalDateTime finish = LocalDateTime.now().plusDays(2);
+
+        // when
+        Task updated = taskService.assignTime(id, start, finish);
+
+        // then
+        assertNotNull(updated);
+        assertEquals(start, updated.startDateTime());
+        assertEquals(finish, updated.finishDateTime());
+        verify(taskRepository).update(updated);
     }
 
     @Test
@@ -154,10 +172,9 @@ class TaskServiceTest {
         when(taskRepository.findById(id)).thenReturn(Optional.of(original));
         //when throws
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                taskService.update(id, "Title", "Description", TaskStatus.NEW, start, finish)
+                taskService.assignTime(id, start, finish)
         );
         assertEquals("Start date cannot be after finish time", ex.getMessage());
     }
-
 
 }

--- a/src/test/java/domen/domain/TaskServiceTest.java
+++ b/src/test/java/domen/domain/TaskServiceTest.java
@@ -3,12 +3,14 @@ package domen.domain;
 import domen.domain.exception.TaskNotFoundException;
 import domen.domain.model.Task;
 import domen.domain.model.TaskStatus;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,7 +35,7 @@ class TaskServiceTest {
         String description = "Description of task";
 
         //when
-        Task task = taskService.create(title, description);
+        Task task = taskService.create(title, description, null, null);
         //then
         assertNotNull(task);
         assertEquals(title, task.title());
@@ -44,7 +46,7 @@ class TaskServiceTest {
         //given
         String invalidTitle = null;
         //when then
-        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> taskService.create(invalidTitle, ""));
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> taskService.create(invalidTitle, "", null, null));
         assertEquals("Title cannot be null or empty", illegalArgumentException.getMessage());
     }
 
@@ -52,11 +54,11 @@ class TaskServiceTest {
     void shouldUpdateTask() {
         //given
         String id = "1";
-        Task original = new Task(id, "Old title", "Old desc", TaskStatus.NEW);
+        Task original = new Task(id, "Old title", "Old desc", TaskStatus.NEW, null, null);
         when(taskRepository.findById(id)).thenReturn(Optional.of(original));
 
         //when
-        Task updated = taskService.updateTask(id, "New title", "New desc", TaskStatus.IN_PROGRESS);
+        Task updated = taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS, null, null);
 
         //then
         assertNotNull(updated);
@@ -70,10 +72,10 @@ class TaskServiceTest {
     void shouldNotUpdateNullTask() {
         //given
         String id = "missing";
-        when(taskRepository.findById(id)).thenReturn(null);
+        when(taskRepository.findById(id)).thenReturn(Optional.empty());
         //when then
         TaskNotFoundException ex = assertThrows(TaskNotFoundException.class, () ->
-                taskService.updateTask(id, "New title", "New desc", TaskStatus.IN_PROGRESS)
+                taskService.update(id, "New title", "New desc", TaskStatus.IN_PROGRESS, null, null)
         );
         assertEquals("Task with id " + id + " not found", ex.getMessage());
 
@@ -83,11 +85,11 @@ class TaskServiceTest {
     void shouldUpdateOnlyNotNull() {
         //given
         String id = "1";
-        Task original = new Task(id, "Old title", "Old desc", TaskStatus.NEW);
+        Task original = new Task(id, "Old title", "Old desc", TaskStatus.NEW, null, null);
         when(taskRepository.findById(id)).thenReturn(Optional.of(original));
 
         //when
-        Task updated = taskService.updateTask(id, "New title", null, null);
+        Task updated = taskService.update(id, "New title", null, null, null, null);
 
         //then
         assertNotNull(updated);
@@ -102,19 +104,59 @@ class TaskServiceTest {
     void shouldNotUpdateNullId() {
         //when then
         assertThrows(IllegalArgumentException.class, () ->
-                taskService.updateTask(null, "New title", "Description", TaskStatus.NEW)
+                taskService.update(null, "New title", "Description", TaskStatus.NEW, null, null)
         );
     }
 
     @Test
     void shouldNotCallUpdate() {
         //given
-        when(taskRepository.findById("id")).thenReturn(null);
+        when(taskRepository.findById("id")).thenReturn(Optional.empty());
         //when/then
         assertThrows(TaskNotFoundException.class, () ->
-                taskService.updateTask("id", "New title", "New desc", TaskStatus.IN_PROGRESS)
+                taskService.update("id", "New title", "New desc", TaskStatus.IN_PROGRESS, null, null)
         );
         verify(taskRepository, never()).update(any());
+    }
+
+    @Test
+    void shouldNotCreateTaskWithStartAfterFinish() {
+        //given
+        LocalDateTime start = LocalDateTime.now().plusDays(2);
+        LocalDateTime finish = LocalDateTime.now().plusDays(1);
+
+        //when throws
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                taskService.create("Title", "Description", start, finish)
+        );
+        assertEquals("Start date cannot be after finish time", ex.getMessage());
+    }
+
+    @Test
+    void shouldNotCreateTaskWithFinishBeforeCurrentTime() {
+        //given
+        LocalDateTime finish = LocalDateTime.now().minusDays(2);
+        //when throws
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                taskService.create("Title", "Description", null, finish)
+        );
+        assertEquals("Finish date cannot be before current time", ex.getMessage());
+    }
+
+    @Test
+    void shouldNotUpdateWithInvalidDate() {
+        //given
+        String id = "1";
+        LocalDateTime start = LocalDateTime.now().plusDays(2);
+        LocalDateTime finish = LocalDateTime.now().plusDays(1);
+
+        Task original = new Task(id, "Old title", "Old desc", TaskStatus.NEW, null, null);
+        when(taskRepository.findById(id)).thenReturn(Optional.of(original));
+        //when throws
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                taskService.update(id, "Title", "Description", TaskStatus.NEW, start, finish)
+        );
+        assertEquals("Start date cannot be after finish time", ex.getMessage());
     }
 
 


### PR DESCRIPTION
## ⏰ Added support for task scheduling (start and finish time)

### 🧱 Task Model

**Updated Fields:**
- `startDateTime`: start date and time of the task
- `finishDateTime`: finish date and time of the task

**Updated  Method:**
- `copyWith(...)`
 - Now accepts `startDateTime` and `finishDateTime`
---

### ⚙️ TaskService

**Updated Methods:**
- `create(...)`:
  - Now accepts `startDateTime` and `finishDateTime`
  - Validates that:
    - Title is not null or empty
    - `startDateTime` is not after `finishDateTime`
    - `finishDateTime` is not in the past

- `updateTask(...)`:
  - Now accepts optional `startDateTime` and `finishDateTime`
  - Performs the same validations as in `create(...)` if new values are provided
  - Keeps unchanged values if arguments are `null`

**Helper:**
- Added private method `validateTaskDateTime(...)` for reusable time-based validation logic

---

### 🧪 Tests

**Updated:**
- All existing tests updated to provide valid `startDateTime` and `finishDateTime`

**Added:**
- New test cases for:
  - Rejecting creation or update if `startDateTime > finishDateTime`
  - Rejecting creation or update if `finishDateTime` is before current time
  - Verifying that validation prevents saving invalid tasks

---
